### PR TITLE
Fix the Ruby on Rails GitHub workflow to run in the correct directory.

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -35,6 +35,8 @@ jobs:
           ruby-version: '3.1'
           bundler-cache: true
       # Add or replace database setup steps here
+      - name: Set working directory
+        run: cd meal-planner
       - name: Set up database schema
         run: bin/rails db:prepare
       # Add or replace test runners here
@@ -46,6 +48,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set working directory
+        run: cd meal-planner
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
The workflow was previously running commands from the root directory instead of the meal-planner directory. This commit modifies the workflow file to change the working directory to 'meal-planner' before executing any commands. This ensures that all subsequent commands are run in the correct directory.