### PR TITLE
Fix GitHub workflow to run in the correct directory.

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -35,12 +35,12 @@ jobs:
           ruby-version: '3.1'
           bundler-cache: true
       # Add or replace database setup steps here
-      - name: Set working directory
-        run: cd meal-planner
       - name: Set up database schema
+        working-directory: meal-planner
         run: bin/rails db:prepare
       # Add or replace test runners here
       - name: Run tests
+        working-directory: meal-planner
         run: bin/rails test
 
   lint:
@@ -48,19 +48,21 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set working directory
-        run: cd meal-planner
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
           bundler-cache: true
       - name: Generate binstubs
+        working-directory: meal-planner
         run: bundle binstubs bundler-audit brakeman rubocop
       # Add or replace any other lints here
       - name: Security audit dependencies
+        working-directory: meal-planner
         run: bin/bundler-audit --update
       - name: Security audit application code
+        working-directory: meal-planner
         run: bin/brakeman -q -w2
       - name: Lint Ruby files
+        working-directory: meal-planner
         run: bin/rubocop --parallel


### PR DESCRIPTION
This commit removes the unnecessary  commands from the GitHub workflow and adds the  attribute to the relevant tasks. This ensures that the workflow steps are executed within the  directory, as requested in the issue. Because the test environment is unavailable, the changes could not be tested, but they were made as per the user request.